### PR TITLE
feat: simplest compiler

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,5 +7,8 @@ WORKDIR /app
 # Copy source code
 COPY . .
 
+RUN go format ./...
+RUN go build -o main .
+
 # Build and run the application
-CMD ["go", "run", "main.go"]
+CMD ["./main"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 
 This project is inspired by [Let's Build a Simple Database](https://cstack.github.io/db_tutorial/), but implemented in Go, the language I’m currently learning.
 
+## Concept
+
+The front-end consists of:
+
+- Tokenizer
+- Parser
+- Code Generator
+
+
+The back-end consists of:
+
+- Virtual Machine
+- B-tree
+- Pager
+- OS Interface
+
+
+## How to run it
+
+```bash
+docker-compose run --rm toydb-dev
+```
+
 
 ## Author
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,35 @@ import (
 	"strings"
 )
 
+// StatementType represents the type of SQL statement
+type StatementType int
+
+const (
+	STATEMENT_INSERT StatementType = iota
+	STATEMENT_SELECT
+)
+
+// Statement holds a parsed SQL statement
+type Statement struct {
+	Type StatementType
+}
+
+// MetaCommandResult represents the result of executing a meta command
+type MetaCommandResult int
+
+const (
+    META_COMMAND_SUCCESS MetaCommandResult = iota
+    META_COMMAND_UNRECOGNIZED_COMMAND
+)
+
+// PrepareResult represents the result of preparing a statement
+type PrepareResult int
+
+const (
+	PREPARE_SUCCESS PrepareResult = iota
+	PREPARE_UNRECOGNIZED_STATEMENT
+)
+
 type InputBuffer struct {
     buffer string
 }
@@ -30,6 +59,38 @@ func (ib *InputBuffer) readInput(reader *bufio.Reader) error {
     return nil
 }
 
+func doMetaCommand(inputBuffer *InputBuffer) MetaCommandResult {
+	if inputBuffer.buffer == ".exit" {
+		fmt.Println("Bye!")
+		os.Exit(0)
+	}
+
+	return META_COMMAND_UNRECOGNIZED_COMMAND
+}
+
+func prepareStatement(inputBuffer *InputBuffer, statement *Statement) PrepareResult {
+	if strings.HasPrefix(inputBuffer.buffer, "insert") {
+		statement.Type = STATEMENT_INSERT
+		return PREPARE_SUCCESS
+	}
+
+	if inputBuffer.buffer == "select" {
+		statement.Type = STATEMENT_SELECT
+		return PREPARE_SUCCESS
+	}
+
+	return PREPARE_UNRECOGNIZED_STATEMENT
+}
+
+func executeStatement(statement *Statement) {
+	switch statement.Type {
+		case STATEMENT_INSERT:
+			fmt.Println("TODO: Insert")
+		case STATEMENT_SELECT:
+			fmt.Println("TODO: SELECT")
+	}
+}
+
 func main() {
 	reader := bufio.NewReader(os.Stdin)
 	inputBuffer := NewInputBuffer()
@@ -41,14 +102,31 @@ func main() {
 
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(1)
+			continue
 		}
 
-		if inputBuffer.buffer == ".exit" {
-			fmt.Println("Bye!")
-			os.Exit(0)
-		} else {
-			fmt.Printf("Unrecognized command '%s'.\n", inputBuffer.buffer)
+		// Check if it's a meta-command
+		if strings.HasPrefix(inputBuffer.buffer, ".") {
+			switch doMetaCommand(inputBuffer) {
+			case META_COMMAND_SUCCESS:
+				continue
+			case META_COMMAND_UNRECOGNIZED_COMMAND:
+				fmt.Printf("Unrecognized command '%s'\n", inputBuffer.buffer)
+				continue
+			}
 		}
+
+		// Otherwise, it's a SQL statement
+		var statement Statement
+		switch prepareStatement(inputBuffer, &statement) {
+		case PREPARE_SUCCESS:
+			// Statement prepared successfully
+		case PREPARE_UNRECOGNIZED_STATEMENT:
+			fmt.Printf("Unrecognized keyword at start of '%s'.\n", inputBuffer.buffer)
+			continue
+		}
+
+		executeStatement(&statement)
+		fmt.Println("Executed.")
 	}
 }


### PR DESCRIPTION
## Context

Differentiate between two types of commands:

- Meta-commands: Commands that start with a dot (.), like `.exit`
- SQL statements: Regular SQL commands like `insert` and `select`

## QA

```
docker-compose run --rm toydb-dev                                                                                                                       1 ↵
db > SELECT * FROM USER
Unrecognized keyword at start of 'SELECT * FROM USER'.
db > SELECT *    
Unrecognized keyword at start of 'SELECT *'.
db > select
TODO: SELECT
Executed.
db > .
Unrecognized command '.'
db > .exit
Bye!
```
