### PR TITLE
feat: an in memory append and only DB

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,39 @@ import (
 	"strings"
 )
 
+// hardcoded DB
+const (
+	COLUMN_USERNAME_SIZE = 32
+	COLUMN_EMAIL_SIZE = 255
+	PAGE_SIZE = 4096
+	TALBE_MAX_PAGES = 100
+)
+
+const (
+	ID_SIZE = 4 // size of uint32
+	USERNAME_SIZE = COLUMN_USERNAME_SIZE
+	EMAIL_SIZE = COLUMN_EMAIL_SIZE
+	ID_OFFSET = 0
+	USERNAME_OFFSET = ID_OFFSET + ID_SIZE
+	EMAIL_OFFSET = USERNAME_OFFSET + USERNAME_SIZE
+	ROW_SIZE = ID_SIZE + USERNAME_SIZE + EMAIL_SIZE
+	ROWS_PER_PAGE = PAGE_SIZE / ROW_SIZE
+	TABLE_MAX_ROWS = ROWS_PER_PAGE * TALBE_MAX_PAGES
+)
+
+// Row represents a single row in our table
+type Row struct {
+	ID uint32
+	Username [COLUMN_USERNAME_SIZE]byte
+	Email [COLUMN_EMAIL_SIZE]byte
+}
+
+// Table represent our in-memory table structure
+type Table struct {
+	NumRows uint32
+	Pages [TALBE_MAX_PAGES][]byte
+}
+
 // StatementType represents the type of SQL statement
 type StatementType int
 
@@ -18,6 +51,7 @@ const (
 // Statement holds a parsed SQL statement
 type Statement struct {
 	Type StatementType
+	RowToInsert Row // Add this field to hold the row data for INSERT statements
 }
 
 // MetaCommandResult represents the result of executing a meta command
@@ -33,7 +67,16 @@ type PrepareResult int
 
 const (
 	PREPARE_SUCCESS PrepareResult = iota
+	PREPARE_SYNTAX_ERROR
 	PREPARE_UNRECOGNIZED_STATEMENT
+)
+
+// ExecuteResult represents the result of executing a statement
+type ExecuteResult int
+
+const (
+	EXECUTE_SUCCESS ExecuteResult = iota
+	EXECUTE_TABLE_FULL
 )
 
 type InputBuffer struct {
@@ -43,6 +86,63 @@ type InputBuffer struct {
 func NewInputBuffer() *InputBuffer {
     return &InputBuffer{}
 }
+
+func NewTable() *Table {
+	return &Table{
+		NumRows: 0,
+	}
+}
+
+/**
+ * +-------------------------------------------------------------+
+ |      (byte(ID), byte(ID>>8), byte(ID>>16), byte(ID>>24))     |
+ |   +---------------------------------------------------------+
+ |   | 0x01 | 0x02 | 0x03 | 0x04 | ..... (Array)               |
+ |   +---------------------------------------------------------+
+ |     Array:                                                |
+ |     `destination`  ->  [0, 1, 2, 3, 4, 5, 6, 7, ..., N]     |
+ +-------------------------------------------------------------+
+ */
+func serializeRow(source *Row, destination []byte) {
+	destination[0] = byte(source.ID)
+	destination[1] = byte(source.ID >> 8)
+	destination[2] = byte(source.ID >> 16)
+	destination[3] = byte(source.ID >> 24)
+
+	copy(destination[USERNAME_OFFSET:], source.Username[:])
+	copy(destination[EMAIL_OFFSET:], source.Email[:])
+}
+
+func deserializeRow(source []byte, destination *Row) {
+     destination.ID = uint32(source[0]) |
+        uint32(source[1])<<8 |
+        uint32(source[2])<<16 |
+        uint32(source[3])<<24
+
+    copy(destination.Username[:], source[USERNAME_OFFSET:USERNAME_OFFSET+USERNAME_SIZE])
+
+    copy(destination.Email[:], source[EMAIL_OFFSET:EMAIL_OFFSET+EMAIL_SIZE])
+}
+
+func (t *Table) rowSlot(rowNum uint32) []byte {
+	pageNum := rowNum / ROWS_PER_PAGE
+
+	if t.Pages[pageNum] == nil {
+		t.Pages[pageNum] = make([]byte, PAGE_SIZE)
+	}
+
+	rowOffset := rowNum % ROWS_PER_PAGE
+	byteOffset := rowOffset * ROW_SIZE
+
+	return t.Pages[pageNum][byteOffset : byteOffset+ROW_SIZE]
+}
+
+func printRow(row *Row) {
+    username := strings.TrimRight(string(row.Username[:]), "\x00")
+    email := strings.TrimRight(string(row.Email[:]), "\x00")
+    fmt.Printf("(%d, %s, %s)\n", row.ID, username, email)
+}
+
 
 func printPrompt() {
 	fmt.Print("db > ")
@@ -69,29 +169,88 @@ func doMetaCommand(inputBuffer *InputBuffer) MetaCommandResult {
 }
 
 func prepareStatement(inputBuffer *InputBuffer, statement *Statement) PrepareResult {
-	if strings.HasPrefix(inputBuffer.buffer, "insert") {
-		statement.Type = STATEMENT_INSERT
-		return PREPARE_SUCCESS
-	}
+	tokens := strings.Fields(inputBuffer.buffer)
 
-	if inputBuffer.buffer == "select" {
-		statement.Type = STATEMENT_SELECT
-		return PREPARE_SUCCESS
-	}
+    if len(tokens) == 0 {
+        return PREPARE_UNRECOGNIZED_STATEMENT
+    }
 
-	return PREPARE_UNRECOGNIZED_STATEMENT
+    switch tokens[0] {
+    case "insert":
+        statement.Type = STATEMENT_INSERT
+
+        if len(tokens) < 4 {
+            return PREPARE_SYNTAX_ERROR
+        }
+
+        // Parse ID
+        var id int
+        _, err := fmt.Sscanf(tokens[1], "%d", &id)
+        if err != nil {
+            return PREPARE_SYNTAX_ERROR
+        }
+        statement.RowToInsert.ID = uint32(id)
+
+        // Parse Username
+        username := tokens[2]
+        if len(username) > COLUMN_USERNAME_SIZE {
+            return PREPARE_SYNTAX_ERROR
+        }
+        copy(statement.RowToInsert.Username[:], username)
+
+        // Parse Email
+        email := tokens[3]
+        if len(email) > COLUMN_EMAIL_SIZE {
+            return PREPARE_SYNTAX_ERROR
+        }
+        copy(statement.RowToInsert.Email[:], email)
+
+        return PREPARE_SUCCESS
+
+    case "select":
+        statement.Type = STATEMENT_SELECT
+        return PREPARE_SUCCESS
+
+    default:
+        return PREPARE_UNRECOGNIZED_STATEMENT
+    }
 }
 
-func executeStatement(statement *Statement) {
-	switch statement.Type {
-		case STATEMENT_INSERT:
-			fmt.Println("TODO: Insert")
-		case STATEMENT_SELECT:
-			fmt.Println("TODO: SELECT")
+func executeInsert(statement *Statement, table *Table) ExecuteResult {
+	if table.NumRows >= TABLE_MAX_ROWS {
+		return EXECUTE_TABLE_FULL
 	}
+
+	rowToInsert := &statement.RowToInsert
+
+	serializeRow(rowToInsert, table.rowSlot(table.NumRows))
+	table.NumRows++
+	return EXECUTE_SUCCESS
 }
+
+func executeSelect(statement *Statement, table *Table) ExecuteResult {
+    var row Row
+    for i := uint32(0); i < table.NumRows; i++ {
+        deserializeRow(table.rowSlot(i), &row)
+        printRow(&row)
+    }
+    return EXECUTE_SUCCESS
+}
+
+func executeStatement(statement *Statement, table *Table) ExecuteResult {
+    switch statement.Type {
+    case STATEMENT_INSERT:
+        return executeInsert(statement, table)
+    case STATEMENT_SELECT:
+        return executeSelect(statement, table)
+    default:
+        return EXECUTE_SUCCESS
+    }
+}
+
 
 func main() {
+	table := NewTable()
 	reader := bufio.NewReader(os.Stdin)
 	inputBuffer := NewInputBuffer()
 
@@ -121,12 +280,20 @@ func main() {
 		switch prepareStatement(inputBuffer, &statement) {
 		case PREPARE_SUCCESS:
 			// Statement prepared successfully
+			case PREPARE_SYNTAX_ERROR:
+            fmt.Println("Syntax error. Could not parse statement.")
+            continue
 		case PREPARE_UNRECOGNIZED_STATEMENT:
 			fmt.Printf("Unrecognized keyword at start of '%s'.\n", inputBuffer.buffer)
 			continue
 		}
 
-		executeStatement(&statement)
-		fmt.Println("Executed.")
+		result := executeStatement(&statement, table)
+		switch result {
+		case EXECUTE_SUCCESS:
+            fmt.Println("Executed.")
+        case EXECUTE_TABLE_FULL:
+            fmt.Println("Error: Table full.")
+        }
 	}
 }


### PR DESCRIPTION
## Content

- Support two operations: inserting a row and printing all rows
- Reside only in memory (no persistence to disk)
- Support a single, hard-coded table

## QA

```
> docker-compose run --rm toydb-dev                                  
db > insert 1 parseweb.dev hello@parseweb.dev
Executed.
db > insert 2 jing.su jing.h.su.tw@gmail.com
Executed.
db > insert
Syntax error. Could not parse statement.
db > select
(1, parseweb.dev, hello@parseweb.dev)
(2, jing.su, jing.h.su.tw@gmail.com)
Executed.
db > .exit
Bye!
```

## QA

```
docker-compose run --rm toydb-dev        
```