### PR TITLE
feat: introduce cursor to make B-tree implementation easier

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,41 +12,47 @@ import (
 // hardcoded DB
 const (
 	COLUMN_USERNAME_SIZE = 32
-	COLUMN_EMAIL_SIZE = 255
-	PAGE_SIZE = 4096
-	TABLE_MAX_PAGES = 100
+	COLUMN_EMAIL_SIZE    = 255
+	PAGE_SIZE            = 4096
+	TABLE_MAX_PAGES      = 100
 )
 
 const (
-	ID_SIZE = 4 // size of uint32
-	USERNAME_SIZE = COLUMN_USERNAME_SIZE
-	EMAIL_SIZE = COLUMN_EMAIL_SIZE
-	ID_OFFSET = 0
+	ID_SIZE         = 4 // size of uint32
+	USERNAME_SIZE   = COLUMN_USERNAME_SIZE
+	EMAIL_SIZE      = COLUMN_EMAIL_SIZE
+	ID_OFFSET       = 0
 	USERNAME_OFFSET = ID_OFFSET + ID_SIZE
-	EMAIL_OFFSET = USERNAME_OFFSET + USERNAME_SIZE
-	ROW_SIZE = ID_SIZE + USERNAME_SIZE + EMAIL_SIZE
-	ROWS_PER_PAGE = PAGE_SIZE / ROW_SIZE
-	TABLE_MAX_ROWS = ROWS_PER_PAGE * TABLE_MAX_PAGES
+	EMAIL_OFFSET    = USERNAME_OFFSET + USERNAME_SIZE
+	ROW_SIZE        = ID_SIZE + USERNAME_SIZE + EMAIL_SIZE
+	ROWS_PER_PAGE   = PAGE_SIZE / ROW_SIZE
+	TABLE_MAX_ROWS  = ROWS_PER_PAGE * TABLE_MAX_PAGES
 )
+
+type Cursor struct {
+	Table      *Table
+	RowNum     uint32
+	EndOfTable bool // Indicates a position one past the last element
+}
 
 // Pager handles reading/writing pages to disk
 type Pager struct {
 	FileDescriptor *os.File
-	FileLength int64
-	Pages [TABLE_MAX_PAGES][]byte
+	FileLength     int64
+	Pages          [TABLE_MAX_PAGES][]byte
 }
 
 // Row represents a single row in our table
 type Row struct {
-	ID uint32
+	ID       uint32
 	Username [COLUMN_USERNAME_SIZE]byte
-	Email [COLUMN_EMAIL_SIZE]byte
+	Email    [COLUMN_EMAIL_SIZE]byte
 }
 
 // Table represent our in-memory table structure
 type Table struct {
 	NumRows uint32
-	Pager *Pager
+	Pager   *Pager
 }
 
 // StatementType represents the type of SQL statement
@@ -59,7 +65,7 @@ const (
 
 // Statement holds a parsed SQL statement
 type Statement struct {
-	Type StatementType
+	Type        StatementType
 	RowToInsert Row // Add this field to hold the row data for INSERT statements
 }
 
@@ -67,8 +73,8 @@ type Statement struct {
 type MetaCommandResult int
 
 const (
-    META_COMMAND_SUCCESS MetaCommandResult = iota
-    META_COMMAND_UNRECOGNIZED_COMMAND
+	META_COMMAND_SUCCESS MetaCommandResult = iota
+	META_COMMAND_UNRECOGNIZED_COMMAND
 )
 
 // PrepareResult represents the result of preparing a statement
@@ -91,56 +97,102 @@ const (
 )
 
 type InputBuffer struct {
-    buffer string
+	buffer string
 }
 
 func NewInputBuffer() *InputBuffer {
-    return &InputBuffer{}
+	return &InputBuffer{}
+}
+
+// tableStart creates a cursor at the beginning of the table
+func tableStart(table *Table) *Cursor {
+	cursor := &Cursor{
+		Table:      table,
+		RowNum:     0,
+		EndOfTable: (table.NumRows == 0),
+	}
+
+	return cursor
+}
+
+// tableEnd creates a cursor past the end of the table
+func tableEnd(table *Table) *Cursor {
+	cursor := &Cursor{
+		Table:      table,
+		RowNum:     table.NumRows,
+		EndOfTable: true,
+	}
+
+	return cursor
+}
+
+// cursorValue returns a slice pointing to the position described by the cursor
+func cursorValue(cursor *Cursor) ([]byte, error) {
+	rowNum := cursor.RowNum
+	pageNum := rowNum / ROWS_PER_PAGE
+
+	page, err := cursor.Table.Pager.getPage(pageNum)
+	if err != nil {
+		return nil, err
+	}
+
+	rowOffset := rowNum % ROWS_PER_PAGE
+	byteOffset := rowOffset * ROW_SIZE
+
+	return page[byteOffset : byteOffset+ROW_SIZE], nil
+}
+
+// cursorAdvance moves the cursor to the next row
+func cursorAdvance(cursor *Cursor) {
+	cursor.RowNum++
+	if cursor.RowNum >= cursor.Table.NumRows {
+		cursor.EndOfTable = true
+	}
 }
 
 // pagerOpen opens the database file and initializes the pager
 func pagerOpen(filename string) (*Pager, error) {
-    // Open file with read/write permissions, create if doesn't exist
-    file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666)
-    if err != nil {
-        return nil, fmt.Errorf("Unable to open file: %v", err)
-    }
+	// Open file with read/write permissions, create if doesn't exist
+	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to open file: %v", err)
+	}
 
-    // Get file size
-    fileInfo, err := file.Stat()
-    if err != nil {
-        file.Close()
-        return nil, fmt.Errorf("Unable to get file info: %v", err)
-    }
+	// Get file size
+	fileInfo, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, fmt.Errorf("Unable to get file info: %v", err)
+	}
 
-    pager := &Pager{
-        FileDescriptor: file,
-        FileLength:     fileInfo.Size(),
-    }
+	pager := &Pager{
+		FileDescriptor: file,
+		FileLength:     fileInfo.Size(),
+	}
 
-    // Initialize all pages to nil
-    for i := 0; i < TABLE_MAX_PAGES; i++ {
-        pager.Pages[i] = nil
-    }
+	// Initialize all pages to nil
+	for i := 0; i < TABLE_MAX_PAGES; i++ {
+		pager.Pages[i] = nil
+	}
 
-    return pager, nil
+	return pager, nil
 }
 
 // dbOpen opens a database connection
 func dbOpen(filename string) (*Table, error) {
-    pager, err := pagerOpen(filename)
-    if err != nil {
-        return nil, err
-    }
+	pager, err := pagerOpen(filename)
+	if err != nil {
+		return nil, err
+	}
 
-    numRows := uint32(pager.FileLength / ROW_SIZE)
+	numRows := uint32(pager.FileLength / ROW_SIZE)
 
-    table := &Table{
-        Pager:   pager,
-        NumRows: numRows,
-    }
+	table := &Table{
+		Pager:   pager,
+		NumRows: numRows,
+	}
 
-    return table, nil
+	return table, nil
 }
 
 func (p *Pager) getPage(pageNum uint32) ([]byte, error) {
@@ -154,57 +206,56 @@ func (p *Pager) getPage(pageNum uint32) ([]byte, error) {
 		numPages := p.FileLength / PAGE_SIZE
 
 		// We might have a partial page at the end of the file
-		if p.FileLength % PAGE_SIZE != 0 {
+		if p.FileLength%PAGE_SIZE != 0 {
 			numPages++
 		}
 
 		if int64(pageNum) < numPages {
 			// Seek to the correct position in the file
-            _, err := p.FileDescriptor.Seek(int64(pageNum)*PAGE_SIZE, 0)
-            if err != nil {
-                return nil, fmt.Errorf("Error seeking file: %v", err)
-            }
+			_, err := p.FileDescriptor.Seek(int64(pageNum)*PAGE_SIZE, 0)
+			if err != nil {
+				return nil, fmt.Errorf("Error seeking file: %v", err)
+			}
 
-            // Read the page
-            bytesRead, err := p.FileDescriptor.Read(page)
-            if err != nil && err != io.EOF {
-                return nil, fmt.Errorf("Error reading file: %v", err)
-            }
+			// Read the page
+			bytesRead, err := p.FileDescriptor.Read(page)
+			if err != nil && err != io.EOF {
+				return nil, fmt.Errorf("Error reading file: %v", err)
+			}
 
-            // If we read less than a full page, that's okay
-            _ = bytesRead
+			// If we read less than a full page, that's okay
+			_ = bytesRead
 		}
 
 		p.Pages[pageNum] = page
 	}
-
 
 	return p.Pages[pageNum], nil
 }
 
 // pagerFlush writes a page to disk
 func (p *Pager) pagerFlush(pageNum uint32, size uint32) error {
-    if p.Pages[pageNum] == nil {
-        return fmt.Errorf("Tried to flush null page")
-    }
+	if p.Pages[pageNum] == nil {
+		return fmt.Errorf("Tried to flush null page")
+	}
 
-    // Seek to the correct position
-    _, err := p.FileDescriptor.Seek(int64(pageNum)*PAGE_SIZE, 0)
-    if err != nil {
-        return fmt.Errorf("Error seeking: %v", err)
-    }
+	// Seek to the correct position
+	_, err := p.FileDescriptor.Seek(int64(pageNum)*PAGE_SIZE, 0)
+	if err != nil {
+		return fmt.Errorf("Error seeking: %v", err)
+	}
 
-    // Write the page
-    bytesWritten, err := p.FileDescriptor.Write(p.Pages[pageNum][:size])
-    if err != nil {
-        return fmt.Errorf("Error writing: %v", err)
-    }
+	// Write the page
+	bytesWritten, err := p.FileDescriptor.Write(p.Pages[pageNum][:size])
+	if err != nil {
+		return fmt.Errorf("Error writing: %v", err)
+	}
 
-    if uint32(bytesWritten) != size {
-        return fmt.Errorf("Wrote %d bytes, expected %d", bytesWritten, size)
-    }
+	if uint32(bytesWritten) != size {
+		return fmt.Errorf("Wrote %d bytes, expected %d", bytesWritten, size)
+	}
 
-    return nil
+	return nil
 }
 
 // dbClose flushes all pages to disk and closes the database
@@ -239,58 +290,44 @@ func dbClose(table *Table) error {
 		}
 	}
 
- // Close the file
-    err := pager.FileDescriptor.Close()
-    if err != nil {
-        return fmt.Errorf("Error closing db file: %v", err)
-    }
+	// Close the file
+	err := pager.FileDescriptor.Close()
+	if err != nil {
+		return fmt.Errorf("Error closing db file: %v", err)
+	}
 
-    return nil
+	return nil
 }
 
-/**
- * +-------------------------------------------------------------+
- |      (byte(ID), byte(ID>>8), byte(ID>>16), byte(ID>>24))     |
- |   +---------------------------------------------------------+
- |   | 0x01 | 0x02 | 0x03 | 0x04 | ..... (Array)               |
- |   +---------------------------------------------------------+
- |     Array:                                                |
- |     `destination`  ->  [0, 1, 2, 3, 4, 5, 6, 7, ..., N]     |
- +-------------------------------------------------------------+
- */
+/*
+*
+  - +-------------------------------------------------------------+
+    |      (byte(ID), byte(ID>>8), byte(ID>>16), byte(ID>>24))     |
+    |   +---------------------------------------------------------+
+    |   | 0x01 | 0x02 | 0x03 | 0x04 | ..... (Array)               |
+    |   +---------------------------------------------------------+
+    |     Array:                                                |
+    |     `destination`  ->  [0, 1, 2, 3, 4, 5, 6, 7, ..., N]     |
+    +-------------------------------------------------------------+
+*/
 func serializeRow(source *Row, destination []byte) {
- 	binary.LittleEndian.PutUint32(destination[ID_OFFSET:], source.ID)
+	binary.LittleEndian.PutUint32(destination[ID_OFFSET:], source.ID)
 
 	copy(destination[USERNAME_OFFSET:], source.Username[:])
 	copy(destination[EMAIL_OFFSET:], source.Email[:])
 }
 
 func deserializeRow(source []byte, destination *Row) {
-    destination.ID = binary.LittleEndian.Uint32(source[ID_OFFSET:])
+	destination.ID = binary.LittleEndian.Uint32(source[ID_OFFSET:])
 
-    copy(destination.Username[:], source[USERNAME_OFFSET:USERNAME_OFFSET+USERNAME_SIZE])
-    copy(destination.Email[:], source[EMAIL_OFFSET:EMAIL_OFFSET+EMAIL_SIZE])
-}
-
-func (t *Table) rowSlot(rowNum uint32) ([]byte, error) {
-	pageNum := rowNum / ROWS_PER_PAGE
-
-	page, err := t.Pager.getPage(pageNum)
-
-	if err != nil {
-		return nil, err
-	}
-
-	rowOffset := rowNum % ROWS_PER_PAGE
-	byteOffset := rowOffset * ROW_SIZE
-
-	return page[byteOffset : byteOffset+ROW_SIZE], nil
+	copy(destination.Username[:], source[USERNAME_OFFSET:USERNAME_OFFSET+USERNAME_SIZE])
+	copy(destination.Email[:], source[EMAIL_OFFSET:EMAIL_OFFSET+EMAIL_SIZE])
 }
 
 func printRow(row *Row) {
-    username := strings.TrimRight(string(row.Username[:]), "\x00")
-    email := strings.TrimRight(string(row.Email[:]), "\x00")
-    fmt.Printf("(%d, %s, %s)\n", row.ID, username, email)
+	username := strings.TrimRight(string(row.Username[:]), "\x00")
+	email := strings.TrimRight(string(row.Email[:]), "\x00")
+	fmt.Printf("(%d, %s, %s)\n", row.ID, username, email)
 }
 
 func printPrompt() {
@@ -298,14 +335,14 @@ func printPrompt() {
 }
 
 func (ib *InputBuffer) readInput(reader *bufio.Reader) error {
-    input, err := reader.ReadString('\n')
-    if err != nil {
-        return fmt.Errorf("Error reading input: %v", err)
-    }
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("Error reading input: %v", err)
+	}
 
-    // Remove the trailing newline
-    ib.buffer = strings.TrimRight(input, "\n\r")
-    return nil
+	// Remove the trailing newline
+	ib.buffer = strings.TrimRight(input, "\n\r")
+	return nil
 }
 
 func doMetaCommand(inputBuffer *InputBuffer, table *Table) MetaCommandResult {
@@ -356,31 +393,31 @@ func prepareInsert(inputBuffer *InputBuffer, statement *Statement) PrepareResult
 
 	email := tokens[3]
 
-    if len(email) > COLUMN_EMAIL_SIZE {
-        return PREPARE_STRING_TOO_LONG
-    }
+	if len(email) > COLUMN_EMAIL_SIZE {
+		return PREPARE_STRING_TOO_LONG
+	}
 
-    copy(statement.RowToInsert.Email[:], email)
+	copy(statement.RowToInsert.Email[:], email)
 
-    return PREPARE_SUCCESS
+	return PREPARE_SUCCESS
 }
 
 func prepareStatement(inputBuffer *InputBuffer, statement *Statement) PrepareResult {
 	tokens := strings.Fields(inputBuffer.buffer)
 
-    if len(tokens) == 0 {
-        return PREPARE_UNRECOGNIZED_STATEMENT
-    }
+	if len(tokens) == 0 {
+		return PREPARE_UNRECOGNIZED_STATEMENT
+	}
 
-    switch tokens[0] {
-    case "insert":
-        return prepareInsert(inputBuffer, statement)
-    case "select":
-        statement.Type = STATEMENT_SELECT
-        return PREPARE_SUCCESS
-    default:
-        return PREPARE_UNRECOGNIZED_STATEMENT
-    }
+	switch tokens[0] {
+	case "insert":
+		return prepareInsert(inputBuffer, statement)
+	case "select":
+		statement.Type = STATEMENT_SELECT
+		return PREPARE_SUCCESS
+	default:
+		return PREPARE_UNRECOGNIZED_STATEMENT
+	}
 }
 
 func executeInsert(statement *Statement, table *Table) ExecuteResult {
@@ -389,57 +426,62 @@ func executeInsert(statement *Statement, table *Table) ExecuteResult {
 	}
 
 	rowToInsert := &statement.RowToInsert
-	slot, err := table.rowSlot(table.NumRows)
+	cursor := tableEnd(table)
+	slot, err := cursorValue(cursor)
 
 	if err != nil {
-        fmt.Printf("Error getting row slot: %v\n", err)
-        return EXECUTE_TABLE_FULL
-    }
+		fmt.Printf("Error getting row slot: %v\n", err)
+		return EXECUTE_TABLE_FULL
+	}
 
-    serializeRow(rowToInsert, slot)
-    table.NumRows++
+	serializeRow(rowToInsert, slot)
+	table.NumRows++
 
-    return EXECUTE_SUCCESS
+	return EXECUTE_SUCCESS
 }
 
 func executeSelect(statement *Statement, table *Table) ExecuteResult {
-    var row Row
-    for i := uint32(0); i < table.NumRows; i++ {
-    	slot, err := table.rowSlot(i)
+	cursor := tableStart(table)
 
-     	if err != nil {
-      		fmt.Printf("Error getting row slot: %v\n", err)
-        	continue
-      	}
-        deserializeRow(slot, &row)
-        printRow(&row)
-    }
-    return EXECUTE_SUCCESS
+	var row Row
+
+	for !cursor.EndOfTable {
+		slot, err := cursorValue(cursor)
+		if err != nil {
+			fmt.Printf("Error getting cursor value: %v\n", err)
+			cursorAdvance(cursor)
+			continue
+		}
+		deserializeRow(slot, &row)
+		printRow(&row)
+		cursorAdvance(cursor)
+	}
+	return EXECUTE_SUCCESS
 }
 
 func executeStatement(statement *Statement, table *Table) ExecuteResult {
-    switch statement.Type {
-    case STATEMENT_INSERT:
-        return executeInsert(statement, table)
-    case STATEMENT_SELECT:
-        return executeSelect(statement, table)
-    default:
-        return EXECUTE_SUCCESS
-    }
+	switch statement.Type {
+	case STATEMENT_INSERT:
+		return executeInsert(statement, table)
+	case STATEMENT_SELECT:
+		return executeSelect(statement, table)
+	default:
+		return EXECUTE_SUCCESS
+	}
 }
 
 func main() {
 	if len(os.Args) < 2 {
-        fmt.Println("Must supply a database filename.")
-        os.Exit(1)
-    }
+		fmt.Println("Must supply a database filename.")
+		os.Exit(1)
+	}
 
-    filename := os.Args[1]
-    table, err := dbOpen(filename)
-    if err != nil {
-        fmt.Printf("Error opening database: %v\n", err)
-        os.Exit(1)
-    }
+	filename := os.Args[1]
+	table, err := dbOpen(filename)
+	if err != nil {
+		fmt.Printf("Error opening database: %v\n", err)
+		os.Exit(1)
+	}
 	reader := bufio.NewReader(os.Stdin)
 	inputBuffer := NewInputBuffer()
 
@@ -467,28 +509,28 @@ func main() {
 		// Otherwise, it's a SQL statement
 		var statement Statement
 		switch prepareStatement(inputBuffer, &statement) {
-			case PREPARE_SUCCESS:
-			    // Statement prepared successfully
-			case PREPARE_STRING_TOO_LONG:
-			    fmt.Println("String is too long.")
-			    continue
-			case PREPARE_NEGATIVE_ID:
-			    fmt.Println("ID must be positive.")
-			    continue
-			case PREPARE_SYNTAX_ERROR:
-			    fmt.Println("Syntax error. Could not parse statement.")
-			    continue
-			case PREPARE_UNRECOGNIZED_STATEMENT:
-			    fmt.Printf("Unrecognized keyword at start of '%s'.\n", inputBuffer.buffer)
-			    continue
+		case PREPARE_SUCCESS:
+			// Statement prepared successfully
+		case PREPARE_STRING_TOO_LONG:
+			fmt.Println("String is too long.")
+			continue
+		case PREPARE_NEGATIVE_ID:
+			fmt.Println("ID must be positive.")
+			continue
+		case PREPARE_SYNTAX_ERROR:
+			fmt.Println("Syntax error. Could not parse statement.")
+			continue
+		case PREPARE_UNRECOGNIZED_STATEMENT:
+			fmt.Printf("Unrecognized keyword at start of '%s'.\n", inputBuffer.buffer)
+			continue
 		}
 
 		result := executeStatement(&statement, table)
 		switch result {
 		case EXECUTE_SUCCESS:
-            fmt.Println("Executed.")
-        case EXECUTE_TABLE_FULL:
-            fmt.Println("Error: Table full.")
-        }
+			fmt.Println("Executed.")
+		case EXECUTE_TABLE_FULL:
+			fmt.Println("Error: Table full.")
+		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,173 +1,173 @@
 package main
 
 import (
-    "fmt"
-    "io"
-    "os"
-    "os/exec"
-    "strings"
-    "testing"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
 )
 
 // runScript executes the database with a series of commands and returns the output
 func runScript(commands []string) ([]string, error) {
-    // Build the executable
-    buildCmd := exec.Command("go", "build", "-o", "testdb", "main.go")
-    if err := buildCmd.Run(); err != nil {
-        return nil, err
-    }
-    defer os.Remove("testdb") // Clean up after test
+	// Build the executable
+	buildCmd := exec.Command("go", "build", "-o", "testdb", "main.go")
+	if err := buildCmd.Run(); err != nil {
+		return nil, err
+	}
+	defer os.Remove("testdb") // Clean up after test
 
-    // Run the database
-    cmd := exec.Command("./testdb")
+	// Run the database
+	cmd := exec.Command("./testdb")
 
-    // Create pipes for stdin and stdout
-    stdin, err := cmd.StdinPipe()
-    if err != nil {
-        return nil, err
-    }
+	// Create pipes for stdin and stdout
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
 
-    stdout, err := cmd.StdoutPipe()
-    if err != nil {
-        return nil, err
-    }
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
 
-    // Start the command
-    if err := cmd.Start(); err != nil {
-        return nil, err
-    }
+	// Start the command
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
 
-    // Send commands
-    for _, command := range commands {
-        io.WriteString(stdin, command+"\n")
-    }
-    stdin.Close()
+	// Send commands
+	for _, command := range commands {
+		io.WriteString(stdin, command+"\n")
+	}
+	stdin.Close()
 
-    // Read output
-    output, err := io.ReadAll(stdout)
-    if err != nil {
-        return nil, err
-    }
+	// Read output
+	output, err := io.ReadAll(stdout)
+	if err != nil {
+		return nil, err
+	}
 
-    // Wait for command to finish
-    cmd.Wait()
+	// Wait for command to finish
+	cmd.Wait()
 
-    // Split output into lines and remove empty lines
-    lines := strings.Split(string(output), "\n")
-    var result []string
-    for _, line := range lines {
-        if line != "" {
-            result = append(result, line)
-        }
-    }
+	// Split output into lines and remove empty lines
+	lines := strings.Split(string(output), "\n")
+	var result []string
+	for _, line := range lines {
+		if line != "" {
+			result = append(result, line)
+		}
+	}
 
-    return result, nil
+	return result, nil
 }
 
 func TestInsertAndRetrieveRow(t *testing.T) {
-    commands := []string{
-        "insert 1 user1 person1@example.com",
-        "select",
-        ".exit",
-    }
+	commands := []string{
+		"insert 1 user1 person1@example.com",
+		"select",
+		".exit",
+	}
 
-    result, err := runScript(commands)
-    if err != nil {
-        t.Fatalf("Failed to run script: %v", err)
-    }
+	result, err := runScript(commands)
+	if err != nil {
+		t.Fatalf("Failed to run script: %v", err)
+	}
 
-    expected := []string{
-        "db > Executed.",
-        "db > (1, user1, person1@example.com)",
-        "Executed.",
-        "db > Bye!",
-    }
+	expected := []string{
+		"db > Executed.",
+		"db > (1, user1, person1@example.com)",
+		"Executed.",
+		"db > Bye!",
+	}
 
-    if !equalSlices(result, expected) {
-        t.Errorf("Expected %v, got %v", expected, result)
-    }
+	if !equalSlices(result, expected) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
 }
 
 func TestNegativeID(t *testing.T) {
-    commands := []string{
-        "insert -1 cstack foo@bar.com",
-        "select",
-        ".exit",
-    }
+	commands := []string{
+		"insert -1 cstack foo@bar.com",
+		"select",
+		".exit",
+	}
 
-    result, err := runScript(commands)
-    if err != nil {
-        t.Fatalf("Failed to run script: %v", err)
-    }
+	result, err := runScript(commands)
+	if err != nil {
+		t.Fatalf("Failed to run script: %v", err)
+	}
 
-    if result[0] != "db > ID must be positive." {
-        t.Errorf("Expected 'db > ID must be positive.', got '%s'", result[0])
-    }
+	if result[0] != "db > ID must be positive." {
+		t.Errorf("Expected 'db > ID must be positive.', got '%s'", result[0])
+	}
 
-    // Select should show no rows
-    if result[1] != "db > Executed." {
-        t.Errorf("Expected 'db > Executed.', got '%s'", result[1])
-    }
+	// Select should show no rows
+	if result[1] != "db > Executed." {
+		t.Errorf("Expected 'db > Executed.', got '%s'", result[1])
+	}
 }
 
 func TestTableFull(t *testing.T) {
-    var commands []string
+	var commands []string
 
-    // Insert 1401 rows (more than our table can hold)
-    for i := 1; i <= 1401; i++ {
-        commands = append(commands,
-            fmt.Sprintf("insert %d user%d person%d@example.com", i, i, i))
-    }
-    commands = append(commands, ".exit")
+	// Insert 1401 rows (more than our table can hold)
+	for i := 1; i <= 1401; i++ {
+		commands = append(commands,
+			fmt.Sprintf("insert %d user%d person%d@example.com", i, i, i))
+	}
+	commands = append(commands, ".exit")
 
-    result, err := runScript(commands)
-    if err != nil {
-        t.Fatalf("Failed to run script: %v", err)
-    }
+	result, err := runScript(commands)
+	if err != nil {
+		t.Fatalf("Failed to run script: %v", err)
+	}
 
-    // Check that the last insert failed
-    lastLine := result[len(result)-2] // -2 because last line is "Bye!"
-    if lastLine != "db > Error: Table full." {
-        t.Errorf("Expected 'db > Error: Table full.', got '%s'", lastLine)
-    }
+	// Check that the last insert failed
+	lastLine := result[len(result)-2] // -2 because last line is "Bye!"
+	if lastLine != "db > Error: Table full." {
+		t.Errorf("Expected 'db > Error: Table full.', got '%s'", lastLine)
+	}
 }
 
 func TestMaxLengthStrings(t *testing.T) {
-    longUsername := strings.Repeat("a", 32)
-    longEmail := strings.Repeat("a", 255)
+	longUsername := strings.Repeat("a", 32)
+	longEmail := strings.Repeat("a", 255)
 
-    commands := []string{
-        fmt.Sprintf("insert 1 %s %s", longUsername, longEmail),
-        "select",
-        ".exit",
-    }
+	commands := []string{
+		fmt.Sprintf("insert 1 %s %s", longUsername, longEmail),
+		"select",
+		".exit",
+	}
 
-    result, err := runScript(commands)
-    if err != nil {
-        t.Fatalf("Failed to run script: %v", err)
-    }
+	result, err := runScript(commands)
+	if err != nil {
+		t.Fatalf("Failed to run script: %v", err)
+	}
 
-    expected := []string{
-        "db > Executed.",
-        fmt.Sprintf("db > (1, %s, %s)", longUsername, longEmail),
-        "Executed.",
-        "db > Bye!",
-    }
+	expected := []string{
+		"db > Executed.",
+		fmt.Sprintf("db > (1, %s, %s)", longUsername, longEmail),
+		"Executed.",
+		"db > Bye!",
+	}
 
-    if !equalSlices(result, expected) {
-        t.Errorf("Expected %v, got %v", expected, result)
-    }
+	if !equalSlices(result, expected) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
 }
 
 // Helper function to compare slices
 func equalSlices(a, b []string) bool {
-    if len(a) != len(b) {
-        return false
-    }
-    for i := range a {
-        if a[i] != b[i] {
-            return false
-        }
-    }
-    return true
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Content

### Cursor Structure

The cursor encapsulates:

- A reference to the table
- The current row number
- A flag indicating if we're past the end of the table

### Cursor Operations

- `tableStart()`: Creates a cursor at the beginning of the table
- `tableEnd()`: Creates a cursor past the last row (for inserting)
- `cursorValue()`: Returns the memory location of the current row
- `cursorAdvance()`: Moves to the next row

### Refactored Execute Functions
Both executeInsert and executeSelect now use cursors instead of directly accessing rows:
`Insert`: Opens a cursor at the end, writes the row, increments row count

```go
cursor := tableEnd(table)
slot, _ := cursorValue(cursor)
serializeRow(rowToInsert, slot)
```


`Select`: Opens a cursor at the start, iterates through all rows

```go
cursor := tableStart(table)
for !cursor.EndOfTable {
    slot, _ := cursorValue(cursor)
    deserializeRow(slot, &row)
    printRow(&row)
    cursorAdvance(cursor)
}
```

## QA

```
╰─$ docker-compose run --rm -T toydb-dev ./main mydb.db                                                                 2 ↵
db > insert 3 jing.su jing.su@gmail.com
Executed.
db > select
(1, cstack, foo@bar.com)
(2, voltorb, volty@example.com)
(3, jing.su, jing.su@gmail.com)
Executed.
db > .exit
Bye!

╰─$ docker-compose run --rm -T toydb-dev ./main mydb.db
db > select
(1, cstack, foo@bar.com)
(2, voltorb, volty@example.com)
(3, jing.su, jing.su@gmail.com)
Executed.
db > .exit
Bye!
```